### PR TITLE
feat: add accessLevel option for C# generated classes

### DIFF
--- a/src/codegen/model/LexerFile.ts
+++ b/src/codegen/model/LexerFile.ts
@@ -9,6 +9,7 @@ import { Lexer } from "./Lexer.js";
 import { OutputFile } from "./OutputFile.js";
 
 export class LexerFile extends OutputFile {
+    public accessLevel?: string;
     public lexer: Lexer;
 
     public namedActions: Map<string, Action>;
@@ -17,6 +18,7 @@ export class LexerFile extends OutputFile {
         super(factory, fileName);
 
         this.namedActions = this.buildNamedActions();
+        this.accessLevel = factory.grammar.getOptionString("accessLevel");
     }
 
 }

--- a/src/codegen/model/ParserFile.ts
+++ b/src/codegen/model/ParserFile.ts
@@ -11,6 +11,7 @@ import { OutputFile } from "./OutputFile.js";
 import type { Parser } from "./Parser.js";
 
 export class ParserFile extends OutputFile {
+    public accessLevel?: string;
     public grammarName: string;
 
     public parser: Parser;
@@ -24,6 +25,7 @@ export class ParserFile extends OutputFile {
         this.namedActions = this.buildNamedActions();
 
         this.grammarName = factory.grammar.name;
+        this.accessLevel = factory.grammar.getOptionString("accessLevel");
 
         if (factory.grammar.getOptionString("contextSuperClass")) {
             this.contextSuperClass = new ActionText(undefined, [factory.grammar.getOptionString("contextSuperClass")]);

--- a/src/default-target-generators/CSharpTargetGenerator.ts
+++ b/src/default-target-generators/CSharpTargetGenerator.ts
@@ -67,6 +67,7 @@ export class CSharpTargetGenerator extends GeneratorBase implements ITargetGener
         this.invariants.grammarName = parserFile.parser.grammarName;
         this.invariants.grammarFileName = parserFile.parser.grammarFileName;
         this.invariants.tokenLabelType = parserFile.TokenLabelType ?? "IToken";
+        this.invariants.accessLevel = parserFile.accessLevel ?? "public";
 
         const className = parserFile.contextSuperClass
             ? this.renderActionChunks([parserFile.contextSuperClass]).join("") : undefined;
@@ -108,6 +109,7 @@ export class CSharpTargetGenerator extends GeneratorBase implements ITargetGener
         this.invariants.grammarName = lexerFile.lexer.grammarName;
         this.invariants.grammarFileName = lexerFile.lexer.grammarFileName;
         this.invariants.tokenLabelType = lexerFile.TokenLabelType ?? "IToken";
+        this.invariants.accessLevel = lexerFile.accessLevel ?? "public";
 
         const result: Lines = this.renderFileHeader(lexerFile);
 
@@ -142,6 +144,7 @@ export class CSharpTargetGenerator extends GeneratorBase implements ITargetGener
         this.invariants.grammarFileName = listenerFile.grammarFileName;
         this.invariants.tokenLabelType = listenerFile.TokenLabelType ?? "IToken";
 
+        const accessLevel = listenerFile.accessLevel ?? "public";
         const result: Lines = this.renderFileHeader(listenerFile);
 
         if (options.package) {
@@ -165,7 +168,7 @@ export class CSharpTargetGenerator extends GeneratorBase implements ITargetGener
             `[System.CodeDom.Compiler.GeneratedCode("ANTLR", "${antlrVersion}")]`,
             `[System.Diagnostics.DebuggerNonUserCode]`,
             `[System.CLSCompliant(false)]`,
-            `public partial class ${listenerFile.grammarName}BaseListener : I${listenerFile.grammarName}Listener {`
+            `${accessLevel} partial class ${listenerFile.grammarName}BaseListener : I${listenerFile.grammarName}Listener {`
         );
 
         const parserName = listenerFile.parserName;
@@ -250,6 +253,7 @@ export class CSharpTargetGenerator extends GeneratorBase implements ITargetGener
         this.invariants.grammarFileName = visitorFile.grammarFileName;
         this.invariants.tokenLabelType = visitorFile.TokenLabelType ?? "IToken";
 
+        const accessLevel = visitorFile.accessLevel ?? "public";
         const result: Lines = this.renderFileHeader(visitorFile);
         if (options.package) {
             result.push(
@@ -277,7 +281,7 @@ export class CSharpTargetGenerator extends GeneratorBase implements ITargetGener
             `[System.CodeDom.Compiler.GeneratedCode("ANTLR", "${antlrVersion}")]`,
             `[System.Diagnostics.DebuggerNonUserCode]`,
             `[System.CLSCompliant(false)]`,
-            `public partial class ${grammarName}BaseVisitor<Result> : AbstractParseTreeVisitor<Result>, ` +
+            `${accessLevel} partial class ${grammarName}BaseVisitor<Result> : AbstractParseTreeVisitor<Result>, ` +
             `I${grammarName}Visitor<Result> {`
         );
 
@@ -336,6 +340,7 @@ export class CSharpTargetGenerator extends GeneratorBase implements ITargetGener
         this.invariants.grammarFileName = listenerFile.grammarFileName;
         this.invariants.tokenLabelType = listenerFile.TokenLabelType ?? "IToken";
 
+        const accessLevel = listenerFile.accessLevel ?? "public";
         const result: Lines = this.renderFileHeader(listenerFile);
         if (options.package) {
             result.push(
@@ -357,7 +362,7 @@ export class CSharpTargetGenerator extends GeneratorBase implements ITargetGener
             `/// </summary>`,
             `[System.CodeDom.Compiler.GeneratedCode("ANTLR", "${antlrVersion}")]`,
             `[System.CLSCompliant(false)]`,
-            `public interface I${listenerFile.grammarName}Listener : IParseTreeListener {`
+            `${accessLevel} interface I${listenerFile.grammarName}Listener : IParseTreeListener {`
         );
 
         const block: Lines = [];
@@ -420,6 +425,7 @@ export class CSharpTargetGenerator extends GeneratorBase implements ITargetGener
         this.invariants.grammarFileName = visitorFile.grammarFileName;
         this.invariants.tokenLabelType = visitorFile.TokenLabelType ?? "IToken";
 
+        const accessLevel = visitorFile.accessLevel ?? "public";
         const result: Lines = this.renderFileHeader(visitorFile);
         if (options.package) {
             result.push(
@@ -441,7 +447,7 @@ export class CSharpTargetGenerator extends GeneratorBase implements ITargetGener
             `/// <typeparam name="Result">The return type of the visit operation.</typeparam>`,
             `[System.CodeDom.Compiler.GeneratedCode("ANTLR", "${antlrVersion}")]`,
             `[System.CLSCompliant(false)]`,
-            `public interface I${visitorFile.grammarName}Visitor<Result> : IParseTreeVisitor<Result> {`
+            `${accessLevel} interface I${visitorFile.grammarName}Visitor<Result> : IParseTreeVisitor<Result> {`
         );
 
         const block: Lines = [];
@@ -1403,6 +1409,7 @@ export class CSharpTargetGenerator extends GeneratorBase implements ITargetGener
 
         const escapedName = struct.escapedName;
         const superClass = this.invariants.contextSuperClass ?? "ParserRuleContext";
+        const accessLevel = this.invariants.accessLevel ?? "public";
 
         let interfaces = "";
         if (struct.interfaces.length > 0) {
@@ -1413,7 +1420,7 @@ export class CSharpTargetGenerator extends GeneratorBase implements ITargetGener
 
         result.push(
             ``,
-            `public partial class ${escapedName} : ${superClass}${interfaces} {`
+            `${accessLevel} partial class ${escapedName} : ${superClass}${interfaces} {`
         );
 
         const decls = this.renderDecls(struct.attrs);
@@ -1519,8 +1526,9 @@ export class CSharpTargetGenerator extends GeneratorBase implements ITargetGener
         const result = this.startRendering("AltLabelStructDecl");
 
         const escapedName = struct.escapedName;
+        const accessLevel = this.invariants.accessLevel ?? "public";
         result.push(
-            `public partial class ${escapedName} : ${this.toTitleCase(currentRule.name)}Context {`
+            `${accessLevel} partial class ${escapedName} : ${this.toTitleCase(currentRule.name)}Context {`
         );
 
         const decls = this.renderDecls(struct.attrs);
@@ -2279,10 +2287,11 @@ export class CSharpTargetGenerator extends GeneratorBase implements ITargetGener
 
         const parserName = this.toTitleCase(this.invariants.recognizerName);
         const superClass = parser.superClass ? this.renderActionChunks([parser.superClass]) : "Parser";
+        const accessLevel = this.invariants.accessLevel ?? "public";
         result.push(
             `[System.CodeDom.Compiler.GeneratedCode("ANTLR", "${antlrVersion}")]`,
             `[System.CLSCompliant(false)]`,
-            `public partial class ${parserName} : ${superClass} {`,
+            `${accessLevel} partial class ${parserName} : ${superClass} {`,
             `    protected static DFA[] decisionToDFA;`,
             `    protected static PredictionContextCache sharedContextCache = new PredictionContextCache();`
         );
@@ -2392,10 +2401,11 @@ export class CSharpTargetGenerator extends GeneratorBase implements ITargetGener
         const result: Lines = [];
 
         const baseClass = lexer.superClass ? this.renderActionChunks([lexer.superClass]) : "Lexer";
+        const accessLevel = this.invariants.accessLevel ?? "public";
         result.push(
             `[System.CodeDom.Compiler.GeneratedCode("ANTLR", "${antlrVersion}")]`,
             `[System.CLSCompliant(false)]`,
-            `public partial class ${lexer.name} : ${baseClass} {`,
+            `${accessLevel} partial class ${lexer.name} : ${baseClass} {`,
             `    protected static DFA[] decisionToDFA;`,
             `    protected static PredictionContextCache sharedContextCache = new PredictionContextCache();`
         );

--- a/tests/specs/TestCSharpCodeGeneration.spec.ts
+++ b/tests/specs/TestCSharpCodeGeneration.spec.ts
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) Mike Lischke. All rights reserved.
+ * Licensed under the BSD 3-clause License. See License.txt in the project root for license information.
+ */
+
+import { describe, expect, it } from "vitest";
+
+await import("../../src/Tool.js"); // To kick off the loading of the tool
+
+import { ParserATNFactory } from "../../src/automata/ParserATNFactory.js";
+import { CodeGenerator } from "../../src/codegen/CodeGenerator.js";
+import { defineConfig } from "../../src/config/config.js";
+import { CSharpTargetGenerator } from "../../src/default-target-generators/CSharpTargetGenerator.js";
+import { Grammar } from "../../src/tool/index.js";
+
+const csGenerator = new CSharpTargetGenerator(false);
+csGenerator.setUp();
+const dummyParameters = defineConfig({
+    grammarFiles: [],
+    generators: [csGenerator],
+    generationOptions: {
+        outputDirectory: "/tmp"
+    }
+});
+
+describe("TestCSharpCodeGeneration", () => {
+    it("CSharpAccessLevelOption", (): void => {
+        const grammarText =
+            "grammar T;\n" +
+            "options { language=CSharp; accessLevel=internal; }\n" +
+            "a : 'a' ;\n";
+
+        const grammar = new Grammar(grammarText);
+        grammar.tool.process(grammar, dummyParameters, false);
+
+        if (!grammar.ast.hasErrors) {
+            const factory = new ParserATNFactory(grammar);
+            grammar.atn = factory.createATN();
+
+            const gen = new CodeGenerator(grammar, csGenerator, dummyParameters.generationOptions);
+            const generatedCode = gen.generateParser(dummyParameters.generationOptions);
+
+            // Verify internal accessibility is used instead of public
+            expect(generatedCode).toContain("internal partial class");
+            expect(generatedCode).not.toContain("public partial class");
+        }
+    });
+
+    it("CSharpDefaultAccessLevel", (): void => {
+        const grammarText =
+            "grammar T;\n" +
+            "options { language=CSharp; }\n" +
+            "a : 'a' ;\n";
+
+        const grammar = new Grammar(grammarText);
+        grammar.tool.process(grammar, dummyParameters, false);
+
+        if (!grammar.ast.hasErrors) {
+            const factory = new ParserATNFactory(grammar);
+            grammar.atn = factory.createATN();
+
+            const gen = new CodeGenerator(grammar, csGenerator, dummyParameters.generationOptions);
+            const generatedCode = gen.generateParser(dummyParameters.generationOptions);
+
+            // Verify public accessibility is used by default
+            expect(generatedCode).toContain("public partial class");
+        }
+    });
+});


### PR DESCRIPTION
This PR adds support for customizing the accessibility level of generated C# classes through the `accessLevel` grammar option in the new TypeScript-based code generator architecture.

Users can now specify access modifiers (e.g., `internal`, `public`) for all generated C# code including parsers, lexers, listeners, visitors, and context classes. This is useful for library developers who want to hide ANTLR-generated implementation details from their public API.

The option can be set in the grammar file or via command-line parameter.

This implements the same feature as #95 but for the new target generator architecture in the `features/target-generators` branch.