### PR TITLE
feat: add None target language for metadata-only (.interp/.tokens) generation

### DIFF
--- a/src/analysis/LeftRecursiveRuleAnalyzer.ts
+++ b/src/analysis/LeftRecursiveRuleAnalyzer.ts
@@ -12,7 +12,7 @@ import { STGroupFile, type STGroup } from "stringtemplate4ts";
 
 import { Constants } from "../Constants.js";
 import { Tool } from "../Tool.js";
-import { CodeGenerator, type SupportedLanguage } from "../codegen/CodeGenerator.js";
+import { CodeGenerator, type ToolLanguage } from "../codegen/CodeGenerator.js";
 import { ANTLRv4Parser } from "../generated/ANTLRv4Parser.js";
 import { OrderedHashMap } from "../misc/OrderedHashMap.js";
 import { dupTree } from "../support/helpers.js";
@@ -57,7 +57,7 @@ export class LeftRecursiveRuleAnalyzer extends LeftRecursiveRuleWalker {
 
     public altAssociativity = new Map<number, Associativity>();
 
-    public constructor(ruleAST: GrammarAST, tool: Tool, ruleName: string, language: SupportedLanguage) {
+    public constructor(ruleAST: GrammarAST, tool: Tool, ruleName: string, language: ToolLanguage) {
         super(new CommonTreeNodeStream(ruleAST),
             tool.errorManager);
         this.tool = tool;

--- a/src/analysis/LeftRecursiveRuleTransformer.ts
+++ b/src/analysis/LeftRecursiveRuleTransformer.ts
@@ -11,7 +11,7 @@ import { CharStream, CommonToken, CommonTokenStream } from "antlr4ng";
 
 import { Constants } from "../Constants.js";
 import { Tool } from "../Tool.js";
-import type { SupportedLanguage } from "../codegen/CodeGenerator.js";
+import type { ToolLanguage } from "../codegen/CodeGenerator.js";
 import { ANTLRv4Lexer } from "../generated/ANTLRv4Lexer.js";
 import { ANTLRv4Parser } from "../generated/ANTLRv4Parser.js";
 import { OrderedHashMap } from "../misc/OrderedHashMap.js";
@@ -99,7 +99,7 @@ export class LeftRecursiveRuleTransformer {
 
     /** @returns true if successful */
     public translateLeftRecursiveRule(context: GrammarRootAST, r: LeftRecursiveRule,
-        language: SupportedLanguage): boolean {
+        language: ToolLanguage): boolean {
         const prevRuleAST = r.ast;
         const ruleName = prevRuleAST.children[0].getText();
         const leftRecursiveRuleWalker = new LeftRecursiveRuleAnalyzer(prevRuleAST, this.tool, ruleName, language);

--- a/src/automata/LexerATNFactory.ts
+++ b/src/automata/LexerATNFactory.ts
@@ -39,7 +39,13 @@ interface ICharactersDataCheckStatus {
 
 export class LexerATNFactory extends ParserATNFactory {
 
-    private codegenTemplates: STGroup;
+    /**
+     * The code generator whose templates are consulted only as a fallback for lexer commands that are not built in.
+     * The templates are loaded lazily (see {@link codegenTemplates}) so that grammars using only built-in commands
+     * (and metadata-only runs with language = None) never touch a target template group.
+     */
+    private readonly codeGenerator: CodeGenerator;
+    private codegenTemplatesCache?: STGroup;
 
     /** Maps from an action index to a {@link LexerAction} object. */
     private indexToActionMap = new Map<number, LexerAction>();
@@ -53,8 +59,18 @@ export class LexerATNFactory extends ParserATNFactory {
         super(g);
 
         // Use code generation to get correct language templates for lexer commands.
-        codeGenerator ??= new CodeGenerator(g);
-        this.codegenTemplates = codeGenerator.templates;
+        this.codeGenerator = codeGenerator ?? new CodeGenerator(g);
+    }
+
+    /**
+     * Lazily resolved target templates, used only as a fallback for non built-in lexer commands. Loading the template
+     * group reads a target `.stg` file from disk, which is avoided entirely for the common case (built-in commands
+     * only), matching the behavior needed for language = None metadata-only generation.
+     */
+    private get codegenTemplates(): STGroup {
+        this.codegenTemplatesCache ??= this.codeGenerator.templates;
+
+        return this.codegenTemplatesCache;
     }
 
     public override createATN(): ATN {

--- a/src/codegen/CodeGenPipeline.ts
+++ b/src/codegen/CodeGenPipeline.ts
@@ -20,6 +20,14 @@ export class CodeGenPipeline {
     }
 
     public process(toolParameters: IToolParameters): void {
+        // When target code generation is disabled (language = None) only the language-agnostic vocab file is written.
+        // The .interp file has already been produced by the tool at this point, and no target sources are emitted.
+        if (this.g.isCodeGenerationDisabled()) {
+            this.gen.writeVocabFile();
+
+            return;
+        }
+
         // All templates are generated in memory to report the most complete error information possible, but actually
         // writing output files stops after the first error is reported.
         const errorCount = this.g.tool.errorManager.errors;

--- a/src/codegen/CodeGenerator.ts
+++ b/src/codegen/CodeGenerator.ts
@@ -37,6 +37,32 @@ export const targetLanguages = [
 
 export type SupportedLanguage = typeof targetLanguages[number];
 
+/**
+ * A pseudo target that disables target code generation. When selected (via `-Dlanguage=None` or an
+ * `options { language = None; }` grammar option) the tool still runs the full grammar/ATN pipeline and writes the
+ * language-agnostic artifacts (`.interp` and `.tokens`), but emits no target language sources (parser, lexer,
+ * listener, visitor). This is useful for consumers that only need the serialized ATN metadata, e.g. alternative
+ * runtimes that read the `.interp` files directly.
+ */
+export const noTargetLanguage = "None";
+
+/** The language identifier used to disable target code generation. */
+export type NoLanguage = typeof noTargetLanguage;
+
+/**
+ * The language value carried by the tool. This is either one of the real target languages or the {@link NoLanguage}
+ * sentinel, which disables code generation.
+ */
+export type ToolLanguage = SupportedLanguage | NoLanguage;
+
+/**
+ * The target language used internally to build the templates that a few pipeline steps need even when no target code
+ * is generated (lexer command fallbacks and the left-recursive rule rewrite). It is only consulted for grammar
+ * constructs whose template output is identical across all targets, so the resulting ATN (and therefore the `.interp`
+ * output) is target independent.
+ */
+export const defaultTargetLanguage: SupportedLanguage = "Java";
+
 /**  General controller for code gen.  Can instantiate sub generator(s). */
 export class CodeGenerator {
     private static readonly vocabFilePattern =
@@ -58,16 +84,23 @@ export class CodeGenerator {
 
     public target: Target;
     public readonly g?: Grammar;
+
+    /**
+     * The language that drives the templates. This is always a real target language: when the tool language is the
+     * {@link noTargetLanguage} sentinel it resolves to {@link defaultTargetLanguage}, so the few pipeline steps that
+     * need templates during ATN construction keep working while no target code is emitted.
+     */
     public readonly language: SupportedLanguage;
 
     private readonly tool?: Tool;
     private readonly lineWidth = 72;
 
-    public constructor(grammarOrLanguage: Grammar | SupportedLanguage) {
+    public constructor(grammarOrLanguage: Grammar | ToolLanguage) {
         this.g = grammarOrLanguage instanceof Grammar ? grammarOrLanguage : undefined;
         this.tool = this.g?.tool;
 
-        this.language = (grammarOrLanguage instanceof Grammar) ? this.g!.getLanguage() : grammarOrLanguage;
+        const toolLanguage = (grammarOrLanguage instanceof Grammar) ? this.g!.getLanguage() : grammarOrLanguage;
+        this.language = toolLanguage === noTargetLanguage ? defaultTargetLanguage : toolLanguage;
         this.target = new (CodeGenerator.languageMap.get(this.language)!)(this);
     }
 

--- a/src/tool/Grammar.ts
+++ b/src/tool/Grammar.ts
@@ -1137,14 +1137,16 @@ export class Grammar implements IGrammar, IAttributeResolver {
         return "combined";
     }
 
-    public getLanguage(): ToolLanguage {
-        const language = this.getOptionString("language") as ToolLanguage | undefined;
-        if (language && language !== noTargetLanguage && !targetLanguages.includes(language)) {
-            this.tool.errorManager.toolError(IssueCode.CannotCreateTargetGenerator, language);
-        }
+public getLanguage(): ToolLanguage {
+    const language = this.getOptionString("language") as ToolLanguage | undefined;
+    if (language && language !== noTargetLanguage && !targetLanguages.includes(language)) {
+        this.tool.errorManager.toolError(IssueCode.CannotCreateTargetGenerator, language);
 
-        return language ?? "Java";
+        return "Java";
     }
+
+    return language ?? "Java";
+}
 
     /**
      * @returns true if target code generation is disabled for this grammar, i.e. the language is the

--- a/src/tool/Grammar.ts
+++ b/src/tool/Grammar.ts
@@ -20,7 +20,7 @@ import { GrammarTreeVisitor } from "../tree/walkers/GrammarTreeVisitor.js";
 
 import { ClassFactory } from "../ClassFactory.js";
 
-import { targetLanguages, type SupportedLanguage } from "../codegen/CodeGenerator.js";
+import { noTargetLanguage, targetLanguages, type ToolLanguage } from "../codegen/CodeGenerator.js";
 import { Constants } from "../Constants.js";
 
 import { CharSupport } from "../misc/CharSupport.js";
@@ -1137,13 +1137,22 @@ export class Grammar implements IGrammar, IAttributeResolver {
         return "combined";
     }
 
-    public getLanguage(): SupportedLanguage {
-        const language = this.getOptionString("language") as SupportedLanguage | undefined;
-        if (language && !targetLanguages.includes(language)) {
+    public getLanguage(): ToolLanguage {
+        const language = this.getOptionString("language") as ToolLanguage | undefined;
+        if (language && language !== noTargetLanguage && !targetLanguages.includes(language)) {
             this.tool.errorManager.toolError(IssueCode.CannotCreateTargetGenerator, language);
         }
 
         return language ?? "Java";
+    }
+
+    /**
+     * @returns true if target code generation is disabled for this grammar, i.e. the language is the
+     * {@link noTargetLanguage} sentinel. In that case the tool still writes the language-agnostic `.interp` and
+     * `.tokens` artifacts but emits no target language sources.
+     */
+    public isCodeGenerationDisabled(): boolean {
+        return this.getLanguage() === noTargetLanguage;
     }
 
     public getOptionString(key: string): string | undefined {

--- a/tests/TestNoTargetLanguage.spec.ts
+++ b/tests/TestNoTargetLanguage.spec.ts
@@ -1,0 +1,172 @@
+/*
+ * Copyright (c) Mike Lischke. All rights reserved.
+ * Licensed under the BSD 3-clause License. See License.txt in the project root for license information.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { mkdtempSync, readdirSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { ToolTestUtils } from "./ToolTestUtils.js";
+
+/**
+ * Tests for the `None` pseudo target language, which runs the full grammar/ATN pipeline and writes the
+ * language-agnostic artifacts (`.interp` and `.tokens`) while emitting no target language sources. The key contract is
+ * that the metadata is byte-identical to what a real target produces.
+ */
+describe("TestNoTargetLanguage", () => {
+    /** File extensions of target language sources that must never be written when the language is None. */
+    const targetSourceExtensions = [
+        ".java", ".ts", ".js", ".go", ".py", ".cpp", ".h", ".cs", ".dart", ".swift", ".php"
+    ];
+
+    /**
+     * Reads all generated files in a directory into a name -> content map. The input grammar sources (`.g4`) that the
+     * test helper writes into the same directory are excluded so only tool output is compared.
+     *
+     * @param dir The directory to read generated files from.
+     *
+     * @returns A map of generated file name to its UTF-8 content.
+     */
+    const readOutput = (dir: string): Map<string, string> => {
+        const result = new Map<string, string>();
+        for (const name of readdirSync(dir)) {
+            if (name.endsWith(".g4")) {
+                continue;
+            }
+
+            result.set(name, readFileSync(join(dir, name), { encoding: "utf-8" }));
+        }
+
+        return result;
+    };
+
+    /**
+     * Generates the given grammar once with a real target (Java) and once with None, then asserts that None
+     * reproduces the language-agnostic artifacts byte-for-byte and emits no target sources.
+     *
+     * @param grammarFileName The file name to write the grammar under.
+     * @param grammarStr The grammar text.
+     * @param expectedAgnosticFiles The language-agnostic files that must be produced (and be identical across both).
+     */
+    const expectMetadataOnly = (grammarFileName: string, grammarStr: string,
+        expectedAgnosticFiles: string[]): void => {
+        const javaDir = mkdtempSync(join(tmpdir(), "AntlrNoneJava"));
+        const noneDir = mkdtempSync(join(tmpdir(), "AntlrNoneNone"));
+        try {
+            const javaQueue = ToolTestUtils.antlrOnString(javaDir, "Java", grammarFileName, grammarStr, false);
+            expect(javaQueue.errors).toHaveLength(0);
+
+            const noneQueue = ToolTestUtils.antlrOnString(noneDir, "None", grammarFileName, grammarStr, false);
+            expect(noneQueue.errors).toHaveLength(0);
+
+            const javaOutput = readOutput(javaDir);
+            const noneOutput = readOutput(noneDir);
+
+            // Every expected language-agnostic file is present in the None output and identical to the Java output.
+            for (const file of expectedAgnosticFiles) {
+                expect(noneOutput.has(file), `${file} should be produced for language=None`).toBe(true);
+                expect(javaOutput.has(file), `${file} should be produced for language=Java`).toBe(true);
+                expect(noneOutput.get(file), `${file} must be byte-identical to the Java output`)
+                    .toBe(javaOutput.get(file));
+            }
+
+            // The None output contains exactly the language-agnostic files and nothing else.
+            expect([...noneOutput.keys()].sort()).toEqual([...expectedAgnosticFiles].sort());
+
+            // No target language sources leaked into the None output.
+            for (const name of noneOutput.keys()) {
+                const isTargetSource = targetSourceExtensions.some((ext) => {
+                    return name.endsWith(ext);
+                });
+                expect(isTargetSource, `${name} is a target source and must not be generated for language=None`)
+                    .toBe(false);
+            }
+        } finally {
+            rmSync(javaDir, { recursive: true });
+            rmSync(noneDir, { recursive: true });
+        }
+    };
+
+    it("writes only .interp and .tokens for a combined grammar", () => {
+        const grammar =
+            "grammar JSON;\n" +
+            "json : value EOF ;\n" +
+            "obj : '{' pair (',' pair)* '}' | '{' '}' ;\n" +
+            "pair : STRING ':' value ;\n" +
+            "arr : '[' value (',' value)* ']' | '[' ']' ;\n" +
+            "value : STRING | NUMBER | obj | arr | 'true' | 'false' | 'null' ;\n" +
+            "STRING : '\"' (~[\"\\\\] | '\\\\' .)* '\"' ;\n" +
+            "NUMBER : '-'? INT ('.' [0-9]+)? ;\n" +
+            "fragment INT : '0' | [1-9] [0-9]* ;\n" +
+            "WS : [ \\t\\n\\r]+ -> skip ;\n";
+
+        expectMetadataOnly("JSON.g4", grammar,
+            ["JSON.interp", "JSON.tokens", "JSONLexer.interp", "JSONLexer.tokens"]);
+    });
+
+    it("produces identical metadata for grammars with actions and semantic predicates", () => {
+        // Embedded actions/predicates are stored as opaque ATN coordinates, so the .interp is target independent even
+        // though the (skipped) generated sources would embed the target code verbatim.
+        const grammar =
+            "grammar Heavy;\n" +
+            "@members { int count = 0; }\n" +
+            "stat : {this.count > 0}? expr ';'\n" +
+            "     | expr ';' {this.count++;}\n" +
+            "     ;\n" +
+            "expr : ID | NUMBER ;\n" +
+            "ID : [a-zA-Z_] [a-zA-Z0-9_]* ;\n" +
+            "NUMBER : [0-9]+ ;\n" +
+            "GATED : '@' {this.count > 0}? [a-z]+ ;\n" +
+            "WS : [ \\t\\r\\n]+ -> skip ;\n";
+
+        expectMetadataOnly("Heavy.g4", grammar,
+            ["Heavy.interp", "Heavy.tokens", "HeavyLexer.interp", "HeavyLexer.tokens"]);
+    });
+
+    it("produces identical metadata for left-recursive grammars", () => {
+        // The left-recursive rule rewrite consults target templates; the resulting ATN is nonetheless identical
+        // across targets, which this asserts against the Java baseline.
+        const grammar =
+            "grammar Expr;\n" +
+            "prog : stat+ ;\n" +
+            "stat : expr ';' ;\n" +
+            "expr : expr '*' expr\n" +
+            "     | expr '+' expr\n" +
+            "     | expr '(' expr ')'\n" +
+            "     | ID\n" +
+            "     | INT\n" +
+            "     ;\n" +
+            "ID : [a-zA-Z]+ ;\n" +
+            "INT : [0-9]+ ;\n" +
+            "WS : [ \\t\\r\\n]+ -> skip ;\n";
+
+        expectMetadataOnly("Expr.g4", grammar,
+            ["Expr.interp", "Expr.tokens", "ExprLexer.interp", "ExprLexer.tokens"]);
+    });
+
+    it("honors the language=None option set inside the grammar", () => {
+        const tempDir = mkdtempSync(join(tmpdir(), "AntlrNoneOption"));
+        try {
+            const grammar =
+                "grammar OptNone;\n" +
+                "options { language=None; }\n" +
+                "r : ID ;\n" +
+                "ID : [a-z]+ ;\n";
+
+            // No -Dlanguage on the command line; the option comes from the grammar itself.
+            const queue = ToolTestUtils.antlrOnString(tempDir, null, "OptNone.g4", grammar, false);
+            expect(queue.errors).toHaveLength(0);
+
+            const produced = readdirSync(tempDir).filter((name) => {
+                return name !== "OptNone.g4";
+            });
+            expect(produced.sort())
+                .toEqual(["OptNone.interp", "OptNone.tokens", "OptNoneLexer.interp", "OptNoneLexer.tokens"].sort());
+        } finally {
+            rmSync(tempDir, { recursive: true });
+        }
+    });
+});


### PR DESCRIPTION
## Summary

Adds a `None` pseudo target language that generates **only** the language-agnostic grammar metadata — `.interp` and `.tokens` — and emits no target-language sources (parser, lexer, listener, visitor).

Select it either on the command line:

```bash
antlr-ng -Dlanguage=None -o build/meta JSON.g4
# writes: JSON.interp, JSON.tokens, JSONLexer.interp, JSONLexer.tokens
```

or from within the grammar:

```antlr
grammar JSON;
options { language=None; }
...
```

## Motivation

Some consumers only need the serialized ATN metadata that ANTLR already computes — for example alternative/experimental runtimes that read the `.interp` files directly rather than using a generated recognizer. Today those users must pick an arbitrary real target (Java by default), let the tool emit a full set of source files, and then discard them. Picking a bogus `-Dlanguage` value instead fails with `ANTLR cannot generate <X> code` plus cascading errors.

This also fits the direction discussed in #58 (decoupling the tool from target-specific concerns): a grammar can be processed for its structure without committing to a target language.

## What changes

- **`CodeGenerator.ts`** — introduces the `noTargetLanguage` (`"None"`) sentinel and the `ToolLanguage = SupportedLanguage | NoLanguage` type. `None` is intentionally kept out of the real `targetLanguages` list (it is not a code-gen target) and resolves to `defaultTargetLanguage` (`Java`) *internally* only for the couple of pipeline steps that need templates during ATN construction.
- **`Grammar.ts`** — `getLanguage()` now accepts `None` without raising `CannotCreateTargetGenerator`; adds `isCodeGenerationDisabled()`.
- **`CodeGenPipeline.ts`** — when code generation is disabled, writes just the vocab (`.tokens`) file and returns. The `.interp` file is already produced earlier by the tool, so no target sources are emitted.
- **`LexerATNFactory.ts`** — the target template group is now loaded **lazily**. It is only consulted as a fallback for lexer commands that are *not* built in; all built-in commands (`skip`, `more`, `mode`, `pushMode`, `popMode`, `type`, `channel`) are handled without templates. This means `None` runs (and normal grammars that use only built-in commands) never read a target `.stg` during ATN construction.
- **`LeftRecursiveRule{Transformer,Analyzer}.ts`** — widen the `language` parameter to `ToolLanguage` so the value can flow through unchanged.

## Correctness

The generated `.interp`/`.tokens` are **byte-identical** to what a real target produces. This holds because actions and predicates are stored in the serialized ATN as opaque coordinates (rule index + action/predicate index), not as target code — so the ATN, and therefore the `.interp`, is target-independent. This was verified empirically:

- Diffing `.interp`/`.tokens` for `None` against the `Java` output for a plain grammar, a grammar with lexer/parser actions **and** semantic predicates, and a left-recursive grammar (which exercises the template-driven rule rewrite) — all identical.
- Cross-checking `.interp` across `Java`/`TypeScript`/`Go`/`Python3`/`CSharp`/`Cpp` for a left-recursive grammar — all identical, confirming the template-consuming steps produce target-independent ATN structure.
- Removing the templates directory from disk: `None` still succeeds and produces all four files, while `Java` fails to load `Java.stg` — proving `None` reads no target templates.

## Tests

New `tests/TestNoTargetLanguage.spec.ts` asserts that `None`:

- produces exactly `.interp` + `.tokens` and no target sources,
- is byte-identical to the `Java` baseline for plain, action/predicate-heavy, and left-recursive grammars,
- honors the in-grammar `options { language=None; }` form.

Full suite: **774 passed, 5 skipped**. `eslint` and `tsc` are clean.
